### PR TITLE
feat: remove phone number normalization

### DIFF
--- a/includes/class-orders-index.php
+++ b/includes/class-orders-index.php
@@ -249,7 +249,7 @@ class Orders_Index extends Index implements RecordsProvider {
 		$record['billing'] = array(
 			'display_name' => $order->get_formatted_billing_full_name(),
 			'email'        => $is_wc_3 ? $order->get_billing_email() : $order->billing_email,
-			'phone'        => $this->normalize_phone_number( $is_wc_3 ? $order->get_billing_phone() : $order->billing_phone ),
+			'phone'        => $is_wc_3 ? $order->get_billing_phone() : $order->billing_phone,
 		);
 
 		$record['shipping'] = array(
@@ -269,10 +269,6 @@ class Orders_Index extends Index implements RecordsProvider {
 		}
 
 		return array( $record );
-	}
-
-	private function normalize_phone_number( $phone ) {
-		return preg_replace( '/[^\d+]/', '', $phone );
 	}
 
 	/**


### PR DESCRIPTION
Current phone number normalization does not play well with other languages for example Arabic digits.
Given the WooCommerce plugin offers a way to hook into the phone number at retrieval, we leave normalization up to the users and be more open regarding what phone numbers are.

Closes: #67