### PR TITLE
add filter to optional backend search

### DIFF
--- a/includes/admin/class-orders-list-page.php
+++ b/includes/admin/class-orders-list-page.php
@@ -159,7 +159,8 @@ class Orders_List_Page {
 		return $this->is_current_screen()
 			&& $query->is_admin
 			&& $query->is_search()
-			&& $query->is_main_query();
+			&& $query->is_main_query()
+			&& apply_filters( 'wc_osa_orders_search_should_filter_query', true, $query );
 	}
 
 	/**


### PR DESCRIPTION
A simple and backwards compatible solution to fix https://github.com/rayrutjes/wc-order-search-admin/issues/63 via (eg.) functions.php
```
function should_wc_osa_orders_filter_search( $value, WP_Query $query ) {
    return false;
}

add_filter( 'wc_osa_orders_search_should_filter_query', 'should_wc_osa_orders_filter_search', 10, 2 );
```