### PR TITLE
Added WC_OSA_* constants

### DIFF
--- a/includes/admin/class-ajax-algolia-account-settings-form.php
+++ b/includes/admin/class-ajax-algolia-account-settings-form.php
@@ -31,12 +31,20 @@ class Ajax_Algolia_Account_Settings_Form {
 
 	public function save_algolia_account_settings() {
 		check_ajax_referer( 'save_algolia_account_settings_nonce' );
-		if ( ! isset( $_POST['app_id'] ) || ! isset( $_POST['search_api_key'] ) || ! isset( $_POST['admin_api_key'] ) ) {
+		if ( 
+			(! isset( $_POST['app_id'] ) && ! defined ( 'WC_OSA_ALGOLIA_APPLICATION_ID' )) || 
+			(! isset( $_POST['search_api_key'] ) && ! defined ( 'WC_OSA_ALGOLIA_SEARCH_API_KEY' )) || 
+			(! isset( $_POST['admin_api_key'] ) && ! defined ( 'WC_OSA_ALGOLIA_ADMIN_API_KEY' ) )
+			) {
 			wp_die( 'Hacker' );
 		}
 
 		try {
-			$this->options->set_algolia_account_settings( $_POST['app_id'], $_POST['search_api_key'], $_POST['admin_api_key'] );
+			$this->options->set_algolia_account_settings( 
+				isset( $_POST['app_id'] ) ? $_POST['app_id'] : '',
+				isset( $_POST['search_api_key'] ) ? $_POST['search_api_key'] : '',
+				isset( $_POST['admin_api_key'] ) ? $_POST['admin_api_key'] : ''
+			);
 		} catch ( \InvalidArgumentException $exception ) {
 			wp_send_json_error(
 				array(

--- a/includes/admin/class-ajax-indexing-options-form.php
+++ b/includes/admin/class-ajax-indexing-options-form.php
@@ -29,12 +29,13 @@ class Ajax_Indexing_Options_Form {
 
 	public function save_indexing_options() {
 		check_ajax_referer( 'save_indexing_options_nonce' );
-		if ( ! isset( $_POST['orders_index_name'] ) || ! isset( $_POST['orders_per_batch'] ) ) {
+		if ( (! isset( $_POST['orders_index_name'] ) && ! defined ( 'WC_OSA_ORDERS_INDEX_NAME' ) ) || 
+			 (! isset( $_POST['orders_per_batch'] ) && ! defined ( 'WC_OSA_ORDERS_PER_BATCH' ) ) ) {
 			wp_die( 'Hacker' );
 		}
 
 		try {
-			$this->options->set_orders_index_name( $_POST['orders_index_name'] );
+			$this->options->set_orders_index_name( isset($_POST['orders_index_name']) ? $_POST['orders_index_name'] : '' );
 		} catch ( \InvalidArgumentException $exception ) {
 			wp_send_json_error(
 				array(
@@ -43,7 +44,15 @@ class Ajax_Indexing_Options_Form {
 			);
 		}
 
-		$this->options->set_orders_to_index_per_batch_count( $_POST['orders_per_batch'] );
+		try {
+			$this->options->set_orders_to_index_per_batch_count( isset($_POST['orders_per_batch']) ? $_POST['orders_per_batch'] : 0 );
+		} catch ( \InvalidArgumentException $exception ) {
+			wp_send_json_error(
+				array(
+					'message' => $exception->getMessage(),
+				)
+			);
+		}
 
 		$response = array(
 			'success' => true,

--- a/includes/admin/views/options.php
+++ b/includes/admin/views/options.php
@@ -60,7 +60,7 @@
 		</table>
 
 		<p class="submit">
-			<button type="submit" class="button button-primary" <?php disabled( defined( 'WC_OSA_ALGOLIA_APPLICATION_ID' ), defined( 'WC_OSA_ALGOLIA_SEARCH_API_KEY' ), defined( 'WC_OSA_ALGOLIA_ADMIN_API_KEY' ) ); ?>><?php esc_html_e( 'Save Algolia account settings', 'wc-order-search-admin' ); ?></button>
+			<button type="submit" class="button button-primary" <?php disabled( defined( 'WC_OSA_ALGOLIA_APPLICATION_ID' ) && defined( 'WC_OSA_ALGOLIA_SEARCH_API_KEY' ) && defined( 'WC_OSA_ALGOLIA_ADMIN_API_KEY' ) ); ?>><?php esc_html_e( 'Save Algolia account settings', 'wc-order-search-admin' ); ?></button>
 		</p>
 	</form>
 
@@ -94,7 +94,7 @@
 		</table>
 
 		<p class="submit">
-			<button type="submit" class="button button-primary" <?php disabled( defined( 'WC_OSA_ORDERS_INDEX_NAME' ), defined( 'WC_OSA_ORDERS_PER_BATCH' ) ); ?>><?php esc_html_e( 'Save orders indexing settings', 'wc-order-search-admin' ); ?></button>
+			<button type="submit" class="button button-primary" <?php disabled( defined( 'WC_OSA_ORDERS_INDEX_NAME' ) && defined( 'WC_OSA_ORDERS_PER_BATCH' ) ); ?>><?php esc_html_e( 'Save orders indexing settings', 'wc-order-search-admin' ); ?></button>
 		</p>
 	</form>
 

--- a/includes/admin/views/options.php
+++ b/includes/admin/views/options.php
@@ -28,7 +28,7 @@
 						<label><?php esc_html_e( 'Algolia Application ID:', 'wc-order-search-admin' ); ?> </label>
 					</th>
 					<td>
-						<input type="text" class="regular-text" name="app_id" value="<?php echo esc_attr( $this->options->get_algolia_app_id() ); ?>">
+						<input type="text" class="regular-text" name="app_id" value="<?php echo esc_attr( $this->options->get_algolia_app_id() ); ?>" <?php disabled( defined( 'WC_OSA_ALGOLIA_APPLICATION_ID' ) ); ?>>
 						<p class="description">You can grab it from your <a href="https://www.algolia.com/api-keys" target="_blank">Algolia admin panel</a>.</p>
 					</td>
 				</tr>
@@ -37,7 +37,7 @@
 						<label><?php esc_html_e( 'Algolia Search API key:', 'wc-order-search-admin' ); ?></label>
 					</th>
 					<td>
-						<input type="text" class="regular-text" name="search_api_key" value="<?php echo esc_attr( $this->options->get_algolia_search_api_key() ); ?>">
+						<input type="text" class="regular-text" name="search_api_key" value="<?php echo esc_attr( $this->options->get_algolia_search_api_key() ); ?>" <?php disabled( defined( 'WC_OSA_ALGOLIA_SEARCH_API_KEY' ) ); ?>>
 						<p class="description">
 							You can grab it from your <a href="https://www.algolia.com/api-keys" target="_blank">Algolia admin panel</a>.
 							<br>
@@ -52,7 +52,7 @@
 						<label><?php esc_html_e( 'Algolia Admin API key:', 'wc-order-search-admin' ); ?></label>
 					</th>
 					<td>
-						<input type="password" class="regular-text" name="admin_api_key" value="<?php echo esc_attr( $this->options->get_algolia_admin_api_key() ); ?>">
+						<input type="password" class="regular-text" name="admin_api_key" value="<?php echo esc_attr( $this->options->get_algolia_admin_api_key() ); ?>" <?php disabled( defined( 'WC_OSA_ALGOLIA_ADMIN_API_KEY' ) ); ?>>
 						<p class="description">You can grab it from your <a href="https://www.algolia.com/api-keys" target="_blank">Algolia admin panel</a>.</p>
 					</td>
 				</tr>
@@ -60,7 +60,7 @@
 		</table>
 
 		<p class="submit">
-			<button type="submit" class="button button-primary"><?php esc_html_e( 'Save Algolia account settings', 'wc-order-search-admin' ); ?></button>
+			<button type="submit" class="button button-primary" <?php disabled( defined( 'WC_OSA_ALGOLIA_APPLICATION_ID' ), defined( 'WC_OSA_ALGOLIA_SEARCH_API_KEY' ), defined( 'WC_OSA_ALGOLIA_ADMIN_API_KEY' ) ); ?>><?php esc_html_e( 'Save Algolia account settings', 'wc-order-search-admin' ); ?></button>
 		</p>
 	</form>
 
@@ -79,7 +79,7 @@
 					<label><?php esc_html_e( 'Orders index name in Algolia:', 'wc-order-search-admin' ); ?></label>
 				</th>
 				<td>
-					<input type="text" class="regular-text" name="orders_index_name" value="<?php echo esc_attr( $this->options->get_orders_index_name() ); ?>">
+					<input type="text" class="regular-text" name="orders_index_name" value="<?php echo esc_attr( $this->options->get_orders_index_name() ); ?>" <?php disabled( defined( 'WC_OSA_ORDERS_INDEX_NAME' ) ); ?>>
 				</td>
 			</tr>
 			<tr>
@@ -87,14 +87,14 @@
 					<label><?php esc_html_e( 'Orders to index per batch:', 'wc-order-search-admin' ); ?></label>
 				</th>
 				<td>
-					<input type="number" name="orders_per_batch"  value="<?php echo esc_attr( $this->options->get_orders_to_index_per_batch_count() ); ?>">
+					<input type="number" name="orders_per_batch"  value="<?php echo esc_attr( $this->options->get_orders_to_index_per_batch_count() ); ?>" <?php disabled( defined( 'WC_OSA_ORDERS_PER_BATCH' ) ); ?>>
 				</td>
 			</tr>
 			</tbody>
 		</table>
 
 		<p class="submit">
-			<button type="submit" class="button button-primary"><?php esc_html_e( 'Save orders indexing settings', 'wc-order-search-admin' ); ?></button>
+			<button type="submit" class="button button-primary" <?php disabled( defined( 'WC_OSA_ORDERS_INDEX_NAME' ), defined( 'WC_OSA_ORDERS_PER_BATCH' ) ); ?>><?php esc_html_e( 'Save orders indexing settings', 'wc-order-search-admin' ); ?></button>
 		</p>
 	</form>
 

--- a/includes/class-options.php
+++ b/includes/class-options.php
@@ -39,16 +39,26 @@ class Options {
 	}
 
 	public function set_algolia_account_settings( $app_id, $search_key, $admin_key ) {
-		$app_id = trim( $app_id );
+		$app_id = defined( 'WC_OSA_ALGOLIA_APPLICATION_ID' ) ? WC_OSA_ALGOLIA_APPLICATION_ID : trim( $app_id ) ;
 		$this->assert_not_empty( $app_id, 'Algolia application ID' );
-		$search_key = trim( $search_key );
+
+		$search_key = defined( 'WC_OSA_ALGOLIA_SEARCH_API_KEY' ) ? WC_OSA_ALGOLIA_SEARCH_API_KEY : trim( $search_key ) ;
 		$this->assert_not_empty( $search_key, 'Algolia search only API key' );
-		$admin_key = trim( $admin_key );
+
+		$admin_key = defined( 'WC_OSA_ALGOLIA_ADMIN_API_KEY' ) ? WC_OSA_ALGOLIA_ADMIN_API_KEY : trim( $admin_key ) ;
 		$this->assert_not_empty( $admin_key, 'Algolia admin API key' );
 
-		update_option( 'wc_osa_alg_app_id', $app_id );
-		update_option( 'wc_osa_alg_search_api_key', $search_key );
-		update_option( 'wc_osa_alg_admin_api_key', $admin_key );
+		if ( ! defined ( 'WC_OSA_ALGOLIA_APPLICATION_ID' ) ) {
+			update_option( 'wc_osa_alg_app_id', $app_id );
+		}
+
+		if ( ! defined ( 'WC_OSA_ALGOLIA_SEARCH_API_KEY' ) ) {
+			update_option( 'wc_osa_alg_search_api_key', $search_key );
+		}
+
+		if ( ! defined ( 'WC_OSA_ALGOLIA_ADMIN_API_KEY' )) {
+			update_option( 'wc_osa_alg_admin_api_key', $admin_key );
+		}
 	}
 
 	public function get_orders_index_name() {
@@ -56,9 +66,12 @@ class Options {
 	}
 
 	public function set_orders_index_name( $orders_index_name ) {
-		$orders_index_name = trim( (string) $orders_index_name );
+		$orders_index_name = defined ( 'WC_OSA_ORDERS_INDEX_NAME' ) ? WC_OSA_ORDERS_INDEX_NAME : trim( (string) $orders_index_name ) ;
 		$this->assert_not_empty( $orders_index_name, 'Orders index name' );
-		update_option( 'wc_osa_orders_index_name', $orders_index_name );
+
+		if ( ! defined ( 'WC_OSA_ORDERS_INDEX_NAME' ) ) {
+			update_option( 'wc_osa_orders_index_name', $orders_index_name );
+		}
 	}
 
 	/**
@@ -69,12 +82,18 @@ class Options {
 	}
 
 	public function set_orders_to_index_per_batch_count( $per_batch ) {
+		if ( defined( 'WC_OSA_ORDERS_PER_BATCH' ) && (int) WC_OSA_ORDERS_PER_BATCH <= 0 ) {
+			throw new \InvalidArgumentException( 'Orders to index per batch should be greater than 0.' );
+		}
+
 		$per_batch = (int) $per_batch;
 		if ( $per_batch <= 0 ) {
 			$per_batch = 500;
 		}
 
-		update_option( 'wc_osa_orders_per_batch', $per_batch );
+		if ( ! defined ( 'WC_OSA_ORDERS_INDEX_NAME' ) ) {
+			update_option( 'wc_osa_orders_per_batch', $per_batch );
+		}
 	}
 
 	private function assert_not_empty( $value, $attribute_name ) {

--- a/includes/class-options.php
+++ b/includes/class-options.php
@@ -27,15 +27,15 @@ class Options {
 	}
 
 	public function get_algolia_app_id() {
-		return get_option( 'wc_osa_alg_app_id', '' );
+		return defined( 'WC_OSA_ALGOLIA_APPLICATION_ID' ) ? WC_OSA_ALGOLIA_APPLICATION_ID : get_option( 'wc_osa_alg_app_id', '' ) ;
 	}
 
 	public function get_algolia_search_api_key() {
-		return get_option( 'wc_osa_alg_search_api_key', '' );
+		return defined( 'WC_OSA_ALGOLIA_SEARCH_API_KEY' ) ? WC_OSA_ALGOLIA_SEARCH_API_KEY : get_option( 'wc_osa_alg_search_api_key', '' ) ;
 	}
 
 	public function get_algolia_admin_api_key() {
-		return get_option( 'wc_osa_alg_admin_api_key', '' );
+		return defined( 'WC_OSA_ALGOLIA_ADMIN_API_KEY' ) ? WC_OSA_ALGOLIA_ADMIN_API_KEY : get_option( 'wc_osa_alg_admin_api_key', '' ) ;
 	}
 
 	public function set_algolia_account_settings( $app_id, $search_key, $admin_key ) {
@@ -52,7 +52,7 @@ class Options {
 	}
 
 	public function get_orders_index_name() {
-		return get_option( 'wc_osa_orders_index_name', 'wc_orders' );
+		return defined( 'WC_OSA_ORDERS_INDEX_NAME' ) ? WC_OSA_ORDERS_INDEX_NAME : get_option( 'wc_osa_orders_index_name', 'wc_orders' ) ;
 	}
 
 	public function set_orders_index_name( $orders_index_name ) {
@@ -65,7 +65,7 @@ class Options {
 	 * @return int
 	 */
 	public function get_orders_to_index_per_batch_count() {
-		return (int) get_option( 'wc_osa_orders_per_batch', 500 );
+		return (int) ( defined( 'WC_OSA_ORDERS_PER_BATCH' ) ? WC_OSA_ORDERS_PER_BATCH : get_option( 'wc_osa_orders_per_batch', 500 ) );
 	}
 
 	public function set_orders_to_index_per_batch_count( $per_batch ) {

--- a/readme.txt
+++ b/readme.txt
@@ -89,7 +89,7 @@ add_filter( 'wc_osa_enable_backend_search', 'should_enable_backend_search', 10, 
 
 = Configuration constants =
 
-By default you can configure the plugin on the included options page, but you can also configure the plugin by using one (or more) of the following constants in your `wp-config.php`. Please note, when a contants is defined the corresponding field will be disabled on the options page.
+By default you can configure the plugin on the included options page, but you can also configure the plugin by using one (or more) of the following constants in your `wp-config.php`. Please note, when a constants is defined the corresponding field will be disabled on the options page.
 
 `
 define ( 'WC_OSA_ALGOLIA_APPLICATION_ID', '<value>' );

--- a/readme.txt
+++ b/readme.txt
@@ -87,6 +87,18 @@ function should_enable_backend_search( $value, WP_Query $query ) {
 add_filter( 'wc_osa_enable_backend_search', 'should_enable_backend_search', 10, 2 );
 `
 
+= Configuration constants =
+
+By default you can configure the plugin on the included options page, but you can also configure the plugin by using one (or more) of the following constants in your `wp-config.php`. Please note, when a contants is defined the corresponding field will be disabled on the options page.
+
+`
+define ( 'WC_OSA_ALGOLIA_APPLICATION_ID', '<value>' );
+define ( 'WC_OSA_ALGOLIA_SEARCH_API_KEY', '<value>' );
+define ( 'WC_OSA_ALGOLIA_ADMIN_API_KEY', '<value>' );
+define ( 'WC_OSA_ORDERS_INDEX_NAME', '<value>' );
+define ( 'WC_OSA_ORDERS_PER_BATCH', '<value>' );
+`
+
 = About Algolia =
 
 This plugin relies on the Algolia service which requires you to [create an account](https://www.algolia.com/getstarted/pass?redirect=true).

--- a/readme.txt
+++ b/readme.txt
@@ -89,7 +89,7 @@ add_filter( 'wc_osa_enable_backend_search', 'should_enable_backend_search', 10, 
 
 = Configuration constants =
 
-By default you can configure the plugin on the included options page, but you can also configure the plugin by using one (or more) of the following constants in your `wp-config.php`. Please note, when a constants is defined the corresponding field will be disabled on the options page.
+By default you can configure the plugin on the included options page, but you can also configure the plugin by using one (or more) of the following constants in your `wp-config.php`. Please note, when constants are defined the corresponding fields will be disabled on the options page.
 
 `
 define ( 'WC_OSA_ALGOLIA_APPLICATION_ID', '<value>' );


### PR DESCRIPTION
Added ability to configure the following constants:

```php
define ( 'WC_OSA_ALGOLIA_APPLICATION_ID', '<value>' );
define ( 'WC_OSA_ALGOLIA_SEARCH_API_KEY', '<value>' );
define ( 'WC_OSA_ALGOLIA_ADMIN_API_KEY', '<value>' );
define ( 'WC_OSA_ORDERS_INDEX_NAME', '<value>' );
define ( 'WC_OSA_ORDERS_PER_BATCH', '<value>' );
```

Please note, when constants are defined the corresponding fields will be disabled on the options page.